### PR TITLE
fix: Publish step not properly passed through

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build Package
-        run: npm run prepublish
+        run: npm run prepublish-ci
       - name: Run Tests
         uses: coactions/setup-xvfb@v1
         with:
@@ -65,9 +65,9 @@ jobs:
           npm version $RELEASE_VERSION
           git tag -a $RELEASE_VERSION -m "$RELEASE_VERSION"
       - name: Package Extension
-        run: npm run package $RELEASE_VERSION --no-git-tag-version --no-update-package-json -o "./rover-runner-$RELEASE_VERSION.vsix"
+        run: npm run package -- $RELEASE_VERSION -o "./rover-runner-$RELEASE_VERSION.vsix"
       - name: Publish to Visual Studio Marketplace
-        run: npm run publish --packagePath "./rover-runner-$RELEASE_VERSION.vsix" --no-git-tag-version --no-update-package-json -p ${{ secrets.VSC_MKTP_PAT }}
+        run: npm run publish -- --packagePath "./rover-runner-$RELEASE_VERSION.vsix" -p ${{ secrets.VSC_MKTP_PAT }}
         if: ${{ github.event.inputs.publishMarketplace == 'yes' }}
       - name: Push Tags
         run: |

--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
   },
   "scripts": {
     "setup": "npm ci",
-    "prepublish": "npm run esbuild-base -- --minify",
+    "prepublish-ci": "npm run esbuild-base -- --minify",
     "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node --target=es2020",
     "build": "npm run esbuild-base -- --sourcemap",
     "watch": "npm run esbuild-base -- --sourcemap --watch",
@@ -225,8 +225,8 @@
     "pretest": "npm run build && npm run lint",
     "lint": "eslint src --ext ts",
     "test": "eslint src --ext ts && tsc",
-    "package": "vsce package",
-    "publish": "vsce publish"
+    "package": "vsce package --no-git-tag-version --no-update-package-json",
+    "publish": "vsce publish --no-git-tag-version --no-update-package-json"
   },
   "devDependencies": {
     "@types/detect-port": "1.3.2",


### PR DESCRIPTION
We were missing the `--` after `npm run {command}` in the workflows. This PR adds those back. Additionally, this PR renames the `prepublish` script to `prepublish-ci` since vsce commands were automatically rerunning it multiple times 