### PR TITLE
fix: Switch github urls to directly reference imgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rover Runner README
 Welcome to the Rover Runner! With this extension you can run your supergraph on your local machine using a mix of local and Apollo-based variant subgraphs
 
-![Menu Screenshot](https://github.com/dowjones/rover-runner/blob/main/media/menuScreenshot.png)
+![Menu Screenshot](https://raw.githubusercontent.com/dowjones/rover-runner/main/media/menuScreenshot.png)
  
 ## Features
 

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
               "onCommand:rover-runner.GenerateTemplate"
             ],
             "media": {
-              "image": "https://github.com/dowjones/rover-runner/blob/main/media/supergraph.png",
+              "image": "https://raw.githubusercontent.com/dowjones/rover-runner/main/media/supergraph.png",
               "altText": "Screenshot of a configured supergraph.json"
             }
           },
@@ -162,7 +162,7 @@
               "onSettingChanged:apolloStudioConfiguration.apolloGraphRef"
             ],
             "media": {
-              "image": "https://github.com/dowjones/rover-runner/blob/main/media/settings.png",
+              "image": "https://raw.githubusercontent.com/dowjones/rover-runner/main/media/settings.png",
               "altText": "Screenshot of the Rover Runner settings"
             }
           }


### PR DESCRIPTION
VSCode can't handle image urls to the Github page so this PR changes the urls to directly link to the images.